### PR TITLE
Changed requirements

### DIFF
--- a/reqs.txt
+++ b/reqs.txt
@@ -1,4 +1,4 @@
 matplotlib
 gtts
 pydub
-PIL
+Pillow


### PR DESCRIPTION
Changed PIL to Pillow as for some reason in Python the installation asks for a different name than the one used to import the library during execution :crab: 
![moon](https://user-images.githubusercontent.com/47745048/119473960-fa08a700-bd4b-11eb-8b88-09751d67cd98.jpg)
